### PR TITLE
Count people, wiggle hand when idle

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,7 +49,7 @@ class Robot:
                 daemon=True)
         self._thread.start()
 
-    def _stop_thread(self(:
+    def _stop_thread(self):
         self._should_shutdown_thread = True
         self._cv.notify()
         self._thread.join()

--- a/main.py
+++ b/main.py
@@ -59,8 +59,8 @@ class Robot:
     async def raise_hand(self):
         with self._mutex:
             self._count += 1
-            await self._servo.move(self.UPPER_POSITION)
             if self._count == 1:
+                await self._servo.move(self.UPPER_POSITION)
                 self._start_thread()
 
     async def lower_hand(self):

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import asyncio
 import contextlib
-import time
 
 from viam.robot.client import RobotClient
 from viam.rpc.dial import DialOptions
@@ -112,9 +111,9 @@ class Robot:
         """
         for _ in range(3):
             await self._servo.move(self.UPPER_POSITION + self.WIGGLE_AMOUNT)
-            time.sleep(0.3)
+            await asyncio.sleep(0.3)
             await self._servo.move(self.UPPER_POSITION)
-            time.sleep(0.3)
+            await asyncio.sleep(0.3)
 
 
 @contextlib.asynccontextmanager

--- a/main.py
+++ b/main.py
@@ -32,7 +32,10 @@ class Robot:
         # We have a background thread that wiggles the hand when it's been
         # raised for a long time. This condition variable is how to shut that
         # down.
-        self.cv = threading.Condition(lock=self.mutex)
+        # It would be intuitive to pass self.mutex to threading.Condition, but
+        # that will result in deadlock when you have the mutex and wait for the
+        # thread to shut down.
+        self.cv = threading.Condition()
         self.should_shutdown_thread = True
         self.thread = None
 

--- a/main.py
+++ b/main.py
@@ -41,6 +41,8 @@ class Robot:
 
     def _start_thread(self):
         self._should_shutdown_thread = False
+        if self._thread is not None:
+            print("LOGIC BUG: starting the thread when it's already started!?")
         self._thread = threading.Thread(
                 target=asyncio.run,
                 args=(self._wiggle_on_inactivity,),
@@ -51,6 +53,7 @@ class Robot:
         self._should_shutdown_thread = True
         self._cv.notify()
         self._thread.join()
+        self._thread = None
 
     async def raise_hand(self):
         with self._mutex:

--- a/main.py
+++ b/main.py
@@ -36,13 +36,9 @@ class Robot:
 
     def _start_wiggler(self):
         self._shut_down_wiggler.clear()
-        if self._wiggler is not None:
-            print("LOGIC BUG: starting the coroutine that's already started!?")
         self._wiggler = asyncio.create_task(self._wiggle_on_inactivity())
 
     async def _stop_wiggler(self):
-        if self._wiggler is None:
-            print("LOGIC BUG: stopping the coroutine when it's not started!?")
         self._shut_down_wiggler.set()
         await self._wiggler
         self._wiggler = None

--- a/main.py
+++ b/main.py
@@ -23,8 +23,8 @@ class Robot:
             refresh_interval=0,
             dial_options=DialOptions(credentials=secrets.creds)
         )
-        self._robot = await RobotClient.at_address(secrets.address, opts)
-        self._servo = Servo.from_robot(self._robot, "servo")
+        self.robot = await RobotClient.at_address(secrets.address, opts)
+        self._servo = Servo.from_robot(self.robot, "servo")
 
         self._mutex = threading.Lock()
         self._count = 0  # Number of hands currently raised

--- a/main.py
+++ b/main.py
@@ -23,74 +23,74 @@ class Robot:
             refresh_interval=0,
             dial_options=DialOptions(credentials=secrets.creds)
         )
-        self.robot = await RobotClient.at_address(secrets.address, opts)
-        self.servo = Servo.from_robot(self.robot, "servo")
+        self._robot = await RobotClient.at_address(secrets.address, opts)
+        self._servo = Servo.from_robot(self._robot, "servo")
 
-        self.mutex = threading.Lock()
-        self.count = 0  # Number of hands currently raised
+        self._mutex = threading.Lock()
+        self._count = 0  # Number of hands currently raised
 
         # We have a background thread that wiggles the hand when it's been
         # raised for a long time. This condition variable is how to shut that
         # down.
-        # It would be intuitive to pass self.mutex to threading.Condition, but
+        # It would be intuitive to pass self._mutex to threading.Condition, but
         # that will result in deadlock when you have the mutex and wait for the
         # thread to shut down.
-        self.cv = threading.Condition()
-        self.should_shutdown_thread = True
-        self.thread = None
+        self._cv = threading.Condition()
+        self._should_shutdown_thread = True
+        self._thread = None
 
     def _start_thread(self):
-        self.should_shutdown_thread = False
-        self.thread = threading.Thread(
+        self._should_shutdown_thread = False
+        self._thread = threading.Thread(
                 target=asyncio.run,
                 args=(self._wiggle_on_inactivity,),
                 daemon=True)
-        self.thread.start()
+        self._thread.start()
 
     def _stop_thread(self(:
-        self.should_shutdown_thread = True
-        self.cv.notify()
-        self.thread.join()
+        self._should_shutdown_thread = True
+        self._cv.notify()
+        self._thread.join()
 
     async def raise_hand(self):
-        with self.mutex:
-            self.count += 1
-            await self.servo.move(self.UPPER_POSITION)
-            if self.count == 1:
+        with self._mutex:
+            self._count += 1
+            await self._servo.move(self.UPPER_POSITION)
+            if self._count == 1:
                 self._start_thread()
 
     async def lower_hand(self):
-        with self.mutex:
-            self.count -= 1
-            if self.count == 0:
-                await self.servo.move(self.LOWER_POSITION)
+        with self._mutex:
+            self._count -= 1
+            if self._count == 0:
+                await self._servo.move(self.LOWER_POSITION)
                 self._stop_thread()
 
     async def set_count(self, new_value):
-        with self.mutex:
-            if self.count == 0 and new_value > 0:
+        with self._mutex:
+            if self._count == 0 and new_value > 0:
                 self._start_thread()
-            self.count = new_value
-            if self.count == 0:
-                await self.servo.move(self.LOWER_POSITION)
+            self._count = new_value
+            if self._count == 0:
+                await self._servo.move(self.LOWER_POSITION)
                 self._stop_thread()
             else:
-                await self.servo.move(self.UPPER_POSITION)
+                await self._servo.move(self.UPPER_POSITION)
 
     async def _wiggle_hand(self):
         for _ in range(3):
-            await self.servo.move(self.UPPER_POSITION + self.WIGGLE_AMOUNT)
+            await self._servo.move(self.UPPER_POSITION + self.WIGGLE_AMOUNT)
             time.sleep(0.3)
-            await self.servo.move(self.UPPER_POSITION)
+            await self._servo.move(self.UPPER_POSITION)
             time.sleep(0.3)
 
     async def _wiggle_on_inactivity(self):
         # This is run in a daemon thread. When the hand is raised and nothing
         # has happened for INACTIVITY_PERIOD_S seconds, we wiggle the hand.
-        with self.cv:
-            while not self.should_shutdown_thread:
-                self.cv.wait(timeout=INACTIVITY_PERIOD_S)
-                if self.should_shutdown_thread:
+        with self._cv:
+            while not self._should_shutdown_thread:
+                self._cv.wait(timeout=INACTIVITY_PERIOD_S)
+                if self._should_shutdown_thread:
                     return
                 await self._wiggle_hand()
 

--- a/main.py
+++ b/main.py
@@ -44,7 +44,7 @@ class Robot:
                 self.should_shutdown_thread = False
                 self.thread = threading.Thread(
                         target=asyncio.run,
-                        args=(self.wiggle_on_inactivity,),
+                        args=(self._wiggle_on_inactivity,),
                         daemon=True)
                 self.thread.start()
 
@@ -65,14 +65,14 @@ class Robot:
             else:
                 await self.servo.move(self.UPPER_POSITION)
 
-    async def wiggle_hand(self):
+    async def _wiggle_hand(self):
         for _ in range(3):
             await self.servo.move(self.UPPER_POSITION + self.WIGGLE_AMOUNT)
             time.sleep(0.3)
             await self.servo.move(self.UPPER_POSITION)
             time.sleep(0.3)
 
-    async def wiggle_on_inactivity(self):
+    async def _wiggle_on_inactivity(self):
         # This is run in a daemon thread. When the hand is raised and nothing
         # has happened for INACTIVITY_PERIOD_S seconds, we wiggle the hand.
         with self.cv:
@@ -80,7 +80,7 @@ class Robot:
                 self.cv.wait(timeout=INACTIVITY_PERIOD_S)
                 if self.should_shutdown_thread:
                     return
-                await self.wiggle_hand()
+                await self._wiggle_hand()
 
 
 @contextlib.asynccontextmanager
@@ -111,7 +111,7 @@ async def main():
                     if count == 1:
                         await robot.raise_hand()
                     elif count == 2:
-                        await robot.wiggle_hand()
+                        await robot._wiggle_hand()
                     else:
                         await robot.lower_hand()
             old_state = button_state

--- a/main.py
+++ b/main.py
@@ -67,16 +67,16 @@ class Robot:
         with self._mutex:
             self._count -= 1
             if self._count == 0:
-                await self._servo.move(self.LOWER_POSITION)
                 self._stop_thread()
+                await self._servo.move(self.LOWER_POSITION)
 
     async def set_count(self, new_value):
         with self._mutex:
             should_start_thread = self._count == 0 and new_value > 0
             self._count = new_value
             if self._count == 0:
-                await self._servo.move(self.LOWER_POSITION)
                 self._stop_thread()
+                await self._servo.move(self.LOWER_POSITION)
             else:
                 await self._servo.move(self.UPPER_POSITION)
                 if should_start_thread:

--- a/main.py
+++ b/main.py
@@ -84,9 +84,11 @@ class Robot:
 
     async def _wiggle_hand(self):
         for _ in range(3):
-            await self._servo.move(self.UPPER_POSITION + self.WIGGLE_AMOUNT)
+            with self._mutex:
+                await self._servo.move(self.UPPER_POSITION + self.WIGGLE_AMOUNT)
             time.sleep(0.3)
-            await self._servo.move(self.UPPER_POSITION)
+            with self._mutex:
+                await self._servo.move(self.UPPER_POSITION)
             time.sleep(0.3)
 
     async def _wiggle_on_inactivity(self):
@@ -119,7 +121,8 @@ async def main():
         should_raise = False
         old_state = False
         while True:
-            button_state = await button.get()
+            with robot._mutex:  # TODO: remove this. The mutex should be private
+                button_state = await button.get()
             if button_state != old_state:
                 print("button state has changed!")
                 if button_state:
@@ -129,7 +132,8 @@ async def main():
                     else:
                         await robot.lower_hand()
             old_state = button_state
-            await led.set(button_state)
+            with robot._mutex:  # TODO: remove this. The mutex should be private
+                await led.set(button_state)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -47,9 +47,9 @@ class Robot:
             print("LOGIC BUG: stopping the coroutine when it's not started!?")
         self._should_shutdown_wiggler = True
         print("stop_wiggler will acquire cv...")
-        with self._cv:
+        async with self._cv:
             print("notifying cv...")
-            self._cv.notify()
+            await self._cv.notify()
         print("joining coroutine...")
         await self._wiggler
         print("joined coroutine!")
@@ -67,10 +67,10 @@ class Robot:
         while not self._should_shutdown_wiggler:
             try:
                 print("going to acquire CV...")
-                with self._cv:
+                async with self._cv:
                     print("acquired CV! waiting for notify or timeout...")
                     #self._cv.wait(timeout=self.INACTIVITY_PERIOD_S)
-                    await asyncio.wait_for(asyncio.shield(self._cv.wait),
+                    await asyncio.wait_for(asyncio.shield(self._cv.wait()),
                                            timeout=self.INACTIVITY_PERIOD_S)
                     print("got notify!")
                     if self._should_shutdown_wiggler:

--- a/main.py
+++ b/main.py
@@ -53,7 +53,7 @@ class Robot:
         """
         try:
             while True:
-                await asyncio.sleep(timeout=self.INACTIVITY_PERIOD_S)
+                await asyncio.sleep(self.INACTIVITY_PERIOD_S)
                 await self._wiggle_hand()
         except asyncio.CancelledError:
             return

--- a/main.py
+++ b/main.py
@@ -56,6 +56,11 @@ class Robot:
         self._wiggler = None
 
     async def raise_hand(self):
+        """
+        Call this to consider 1 extra person in the audience to have raised
+        their hand. If this is the first person to do so, we'll raise our
+        servo, and otherwise we take no action.
+        """
         print("Acquiring mutex to raise hand...")
         async with self._mutex:
             print("Acquired mutex to raise hand!")
@@ -66,6 +71,11 @@ class Robot:
         print("released mutex from raise")
 
     async def lower_hand(self):
+        """
+        Call this to consider 1 extra person in the audience to have lowered
+        their hand. If this is the last person who had their hand raised, we'll
+        lower our servo, and otherwise take no action.
+        """
         print("Acquiring mutex to lower hand...")
         async with self._mutex:
             print("Acquired mutex to lower hand!")
@@ -76,6 +86,11 @@ class Robot:
         print("released mutex from lower")
 
     async def set_count(self, new_value):
+        """
+        Call this to set the number of hands raised in the audience to a certain
+        value. This is mainly used to "reset" the count of raised hands if
+        someone forgets to lower their hand.
+        """
         async with self._mutex:
             should_start_wiggler = self._count == 0 and new_value > 0
             self._count = new_value
@@ -88,6 +103,10 @@ class Robot:
                     self._start_wiggler()
 
     async def _wiggle_hand(self):
+        """
+        This moves the servo to wiggle the hand, intended to be used when we've
+        had the hand raised for a while.
+        """
         for _ in range(3):
             print("acquiring wiggle mutex 1...")
             async with self._mutex:
@@ -103,6 +122,11 @@ class Robot:
             time.sleep(0.3)
 
     async def _wiggle_on_inactivity(self):
+        """
+        This is a background coroutine that wiggles the hand if it's been
+        running for a long time. It is started when the count of raised hands
+        becomes nonzero, and stopped when the count goes back to 0.
+        """
         # This is run in a separate coroutine. When the hand is raised and
         # nothing has happened for INACTIVITY_PERIOD_S seconds, we wiggle the
         # hand.

--- a/main.py
+++ b/main.py
@@ -31,32 +31,20 @@ class Robot:
         # We have a background coroutine that wiggles the hand when it's been
         # raised for a long time. This condition variable is how to shut that
         # down.
-        self._cv = asyncio.Event()
-        self._should_shutdown_wiggler = True
+        self._shut_down_wiggler = asyncio.Event()
         self._wiggler = None
 
     def _start_wiggler(self):
-        self._should_shutdown_wiggler = False
-        self._cv.clear()
+        self._shut_down_wiggler.clear()
         if self._wiggler is not None:
             print("LOGIC BUG: starting the coroutine that's already started!?")
-        print("starting wiggler...")
         self._wiggler = asyncio.create_task(self._wiggle_on_inactivity())
 
     async def _stop_wiggler(self):
         if self._wiggler is None:
             print("LOGIC BUG: stopping the coroutine when it's not started!?")
-        self._should_shutdown_wiggler = True
-        print("stop_wiggler will acquire cv...")
-        """
-        async with self._cv:
-            print("notifying cv...")
-            self._cv.notify()
-            """
-        self._cv.set()
-        print("joining coroutine...")
+        self._shut_down_wiggler.set()
         await self._wiggler
-        print("joined coroutine!")
         self._wiggler = None
 
     async def _wiggle_on_inactivity(self):
@@ -68,25 +56,13 @@ class Robot:
         # This is run in a separate coroutine. When the hand is raised and
         # nothing has happened for INACTIVITY_PERIOD_S seconds, we wiggle the
         # hand.
-        while not self._should_shutdown_wiggler:
+        while True:
             try:
-                print("going to acquire CV...")
-                #async with self._cv:
-                print("acquired CV! waiting for notify or timeout...")
-                #self._cv.wait(timeout=self.INACTIVITY_PERIOD_S)
-                await asyncio.wait_for(self._cv.wait(),
+                await asyncio.wait_for(self._shut_down_wiggler.wait(),
                                        timeout=self.INACTIVITY_PERIOD_S)
-                #await asyncio.wait_for(asyncio.shield(self._cv.wait()),
-                #                       timeout=self.INACTIVITY_PERIOD_S)
-                print("got notify!")
-                if self._should_shutdown_wiggler:
-                    print("returning from wiggler (and releasing CV)")
-                    return
-                # unindented to here
+                return
             except TimeoutError:
-                print("(released CV) got timeout! wiggling hand...")
                 await self._wiggle_hand()
-                print("done wiggling, back to top of loop...")
 
     async def raise_hand(self):
         """
@@ -94,14 +70,11 @@ class Robot:
         their hand. If this is the first person to do so, we'll raise our
         servo, and otherwise we take no action.
         """
-        print("Acquiring mutex to raise hand...")
         async with self._mutex:
-            print("Acquired mutex to raise hand!")
             self._count += 1
             if self._count == 1:
                 await self._servo.move(self.UPPER_POSITION)
                 self._start_wiggler()
-        print("released mutex at end of raising hand")
 
     async def lower_hand(self):
         """
@@ -109,14 +82,11 @@ class Robot:
         their hand. If this is the last person who had their hand raised, we'll
         lower our servo, and otherwise take no action.
         """
-        print("Acquiring mutex to lower hand...")
         async with self._mutex:
-            print("Acquired mutex to lower hand!")
             self._count -= 1
             if self._count == 0:
                 await self._stop_wiggler()
                 await self._servo.move(self.LOWER_POSITION)
-        print("released mutex from lower")
 
     async def set_count(self, new_value):
         """
@@ -141,17 +111,11 @@ class Robot:
         had the hand raised for a while.
         """
         for _ in range(3):
-            print("acquiring wiggle mutex 1...")
             async with self._mutex:
-                print("moving wiggle 1...")
                 await self._servo.move(self.UPPER_POSITION + self.WIGGLE_AMOUNT)
-            print("done moving wiggle 1!")
             time.sleep(0.3)
-            print("acquiring wiggle mutex 2...")
             async with self._mutex:
-                print("moving wiggle 2...")
                 await self._servo.move(self.UPPER_POSITION)
-            print("done moving wiggle 2!")
             time.sleep(0.3)
 
 
@@ -174,12 +138,9 @@ async def main():
         should_raise = False
         old_state = False
         while True:
-            #print("acquiring mutex to check button...")
             # TODO: remove this. The mutex should be private
             async with robot._mutex:
-                #print("acquired mutex to check button!")
                 button_state = await button.get()
-            #print("released mutex from button")
             if button_state != old_state:
                 print("button state has changed to {}!".format(button_state))
                 if button_state:
@@ -189,12 +150,9 @@ async def main():
                     else:
                         await robot.lower_hand()
             old_state = button_state
-            #print("acquiring mutex to set LED...")
             # TODO: remove this. The mutex should be private
             async with robot._mutex:
-                #print("acquired mutex to set LED!")
                 await led.set(button_state)
-            #print("released mutex from LED")
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -17,6 +17,11 @@ class Robot:
     INACTIVITY_PERIOD_S = 5
 
     async def connect(self):
+        """
+        This function does the initialization that would normally go in
+        __init__(), except we need asyncio functionality, so we put it here
+        instead.
+        """
         opts = RobotClient.Options(
             refresh_interval=0,
             dial_options=DialOptions(credentials=secrets.creds)

--- a/main.py
+++ b/main.py
@@ -111,19 +111,16 @@ async def main():
         button = await pi.gpio_pin_by_name("18")
         led = await pi.gpio_pin_by_name("16")
 
-        count = 0
+        should_raise = False
         old_state = False
         while True:
             button_state = await button.get()
             if button_state != old_state:
                 print("button state has changed!")
                 if button_state:
-                    count += 1
-                    count %= 3
-                    if count == 1:
+                    should_raise = not should_raise
+                    if should_raise:
                         await robot.raise_hand()
-                    elif count == 2:
-                        await robot._wiggle_hand()
                     else:
                         await robot.lower_hand()
             old_state = button_state

--- a/main.py
+++ b/main.py
@@ -92,12 +92,12 @@ class Robot:
     async def _wiggle_on_inactivity(self):
         # This is run in a daemon thread. When the hand is raised and nothing
         # has happened for INACTIVITY_PERIOD_S seconds, we wiggle the hand.
-        with self._cv:
-            while not self._should_shutdown_thread:
+        while not self._should_shutdown_thread:
+            with self._cv:
                 self._cv.wait(timeout=self.INACTIVITY_PERIOD_S)
-                if self._should_shutdown_thread:
-                    return
-                await self._wiggle_hand()
+            if self._should_shutdown_thread:
+                return
+            await self._wiggle_hand()
 
 
 @contextlib.asynccontextmanager

--- a/main.py
+++ b/main.py
@@ -107,7 +107,7 @@ class Robot:
             print("Acquired mutex to lower hand!")
             self._count -= 1
             if self._count == 0:
-                self._stop_wiggler()
+                await self._stop_wiggler()
                 await self._servo.move(self.LOWER_POSITION)
         print("released mutex from lower")
 
@@ -121,7 +121,7 @@ class Robot:
             should_start_wiggler = self._count == 0 and new_value > 0
             self._count = new_value
             if self._count == 0:
-                self._stop_wiggler()
+                await self._stop_wiggler()
                 await self._servo.move(self.LOWER_POSITION)
             else:
                 await self._servo.move(self.UPPER_POSITION)

--- a/main.py
+++ b/main.py
@@ -71,14 +71,15 @@ class Robot:
 
     async def set_count(self, new_value):
         with self._mutex:
-            if self._count == 0 and new_value > 0:
-                self._start_thread()
+            should_start_thread = self._count == 0 and new_value > 0
             self._count = new_value
             if self._count == 0:
                 await self._servo.move(self.LOWER_POSITION)
                 self._stop_thread()
             else:
                 await self._servo.move(self.UPPER_POSITION)
+                if should_start_thread:
+                    self._start_thread()
 
     async def _wiggle_hand(self):
         for _ in range(3):

--- a/main.py
+++ b/main.py
@@ -49,7 +49,7 @@ class Robot:
         print("stop_wiggler will acquire cv...")
         async with self._cv:
             print("notifying cv...")
-            await self._cv.notify()
+            self._cv.notify()
         print("joining coroutine...")
         await self._wiggler
         print("joined coroutine!")
@@ -94,7 +94,7 @@ class Robot:
             if self._count == 1:
                 await self._servo.move(self.UPPER_POSITION)
                 self._start_wiggler()
-        print("released mutex from raise")
+        print("released mutex at end of raising hand")
 
     async def lower_hand(self):
         """
@@ -174,7 +174,7 @@ async def main():
                 button_state = await button.get()
             #print("released mutex from button")
             if button_state != old_state:
-                print("button state has changed!")
+                print("button state has changed to {}!".format(button_state))
                 if button_state:
                     should_raise = not should_raise
                     if should_raise:

--- a/main.py
+++ b/main.py
@@ -111,11 +111,9 @@ class Robot:
         had the hand raised for a while.
         """
         for _ in range(3):
-            async with self._mutex:
-                await self._servo.move(self.UPPER_POSITION + self.WIGGLE_AMOUNT)
+            await self._servo.move(self.UPPER_POSITION + self.WIGGLE_AMOUNT)
             time.sleep(0.3)
-            async with self._mutex:
-                await self._servo.move(self.UPPER_POSITION)
+            await self._servo.move(self.UPPER_POSITION)
             time.sleep(0.3)
 
 
@@ -138,9 +136,7 @@ async def main():
         should_raise = False
         old_state = False
         while True:
-            # TODO: remove this. The mutex should be private
-            async with robot._mutex:
-                button_state = await button.get()
+            button_state = await button.get()
             if button_state != old_state:
                 print("button state has changed to {}!".format(button_state))
                 if button_state:
@@ -150,9 +146,7 @@ async def main():
                     else:
                         await robot.lower_hand()
             old_state = button_state
-            # TODO: remove this. The mutex should be private
-            async with robot._mutex:
-                await led.set(button_state)
+            await led.set(button_state)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The class now stores how many people have their hand raised: you can increment or decrement this value, or set it to some specific value (which might be unused in the final product, but will help with a PoC before we integrate with Zoom). When the hand has been raised for sufficiently long, it wiggles (or is supposed to, see below).

The current main function now uses the button to toggle between 1 person raising and lowering the hand (so, it doesn't actually demonstrate that we do the right thing multiple people yet). I imagine the next PR after this will be to add a server that takes in requests to raise and lower the hand, at which point we can get rid of the button and the busy loop, and demonstrate support for multiple people (and also enable remote folks to play with the code, since you no longer need to push the button).

There is something subtly wrong with this: raising the hand works fine, lowering the hand works fine, and if you raise it and wait, it _starts_ the wiggle. but then it prints out the following, and everything locks up:
```
button state has changed!
2023-05-18T17:30:50.192256Z ERROR viam_rust_utils::rpc::client_channel: error deserializing message: channel closed    
2023-05-18T17:30:50.192400Z ERROR viam_rust_utils::rpc::client_stream: Error sending trailers to http response: channel closed
```
I don't yet see what the problem is, and could use some help. I don't even really grok the error, TBH! I'm sending out this PR so that other folks can take a look and perhaps find the bug while I'm not around. 