### PR TITLE
Bugfixes and refactorings

### DIFF
--- a/main.py
+++ b/main.py
@@ -89,15 +89,17 @@ class Robot:
         someone forgets to lower their hand.
         """
         async with self._mutex:
-            should_start_wiggler = self._count == 0 and new_value > 0
+            should_raise_servo = self._count == 0 and new_value > 0
+            should_lower_servo = self._count > 0 and new_value == 0
+
             self._count = new_value
-            if self._count == 0:
+
+            if should_raise_servo:
+                await self._servo.move(self.UPPER_POSITION)
+                self._start_wiggler()
+            if should_lower_servo:
                 await self._stop_wiggler()
                 await self._servo.move(self.LOWER_POSITION)
-            else:
-                await self._servo.move(self.UPPER_POSITION)
-                if should_start_wiggler:
-                    self._start_wiggler()
 
     async def _wiggle_hand(self):
         """

--- a/main.py
+++ b/main.py
@@ -16,6 +16,24 @@ class Robot:
     WIGGLE_AMOUNT = 5
     INACTIVITY_PERIOD_S = 5
 
+    async def __enter__(self):
+        # This will become an asyncio.Task when the hand is raised. It will
+        # wiggle the hand when it has been raised for over INACTIVITY_PERIOD_S
+        # seconds.
+        self._wiggler = None
+
+        opts = RobotClient.Options(
+            refresh_interval=0,
+            dial_options=DialOptions(credentials=secrets.creds)
+        )
+        self._robot = await RobotClient.at_address(secrets.address, opts)
+        self._servo = Servo.from_robot(self._robot, "servo")
+        await self._servo.move(self.LOWER_POSITION)
+        return self
+
+    async def __exit__(self, *exception_data):
+        await self._robot.close()
+
     # TODO: remove this when we're ready
     def get_pi(self):
         return Board.from_robot(self._robot, "pi")
@@ -64,24 +82,6 @@ class Robot:
         await self._wiggler
         self._wiggler = None
         await self._servo.move(self.LOWER_POSITION)
-
-    async def __enter__(self):
-        # This will become an asyncio.Task when the hand is raised. It will
-        # wiggle the hand when it has been raised for over INACTIVITY_PERIOD_S
-        # seconds.
-        self._wiggler = None
-
-        opts = RobotClient.Options(
-            refresh_interval=0,
-            dial_options=DialOptions(credentials=secrets.creds)
-        )
-        self._robot = await RobotClient.at_address(secrets.address, opts)
-        self._servo = Servo.from_robot(self._robot, "servo")
-        await self._servo.move(self.LOWER_POSITION)
-        return self
-
-    async def __exit__(self, *exception_data):
-        await self._robot.close()
 
 
 class Audience:

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ class Robot:
     WIGGLE_AMOUNT = 5
     INACTIVITY_PERIOD_S = 5
 
-    async def __enter__(self):
+    async def __aenter__(self):
         opts = RobotClient.Options(
             refresh_interval=0,
             dial_options=DialOptions(credentials=secrets.creds)
@@ -32,7 +32,7 @@ class Robot:
         await self._servo.move(self.LOWER_POSITION)
         return self
 
-    async def __exit__(self, *exception_data):
+    async def __aexit__(self, *exception_data):
         await self._robot.close()
 
     # TODO: remove this when we're ready

--- a/main.py
+++ b/main.py
@@ -60,7 +60,12 @@ class Robot:
         """
         Call this to move the servo to the raised position and start the task
         that wiggles the hand on inactivity.
+
+        Note: this function is not thread safe!
         """
+        if self._wiggler is not None:
+            print("LOGIC BUG: trying to raise already-raised hand")
+            return
         await self._servo.move(self.UPPER_POSITION)
         self._wiggler = asyncio.create_task(self._wiggle_on_inactivity())
 
@@ -68,7 +73,12 @@ class Robot:
         """
         Call this to move the servo to the lowered position and stop the
         background task that wiggles the hand once in a while.
+
+        Note: this function is not thread safe!
         """
+        if self._wiggler is None:
+            print("LOGIC BUG: trying to lower already-lowered hand")
+            return
         self._wiggler.cancel()
         await self._wiggler
         self._wiggler = None

--- a/main.py
+++ b/main.py
@@ -30,9 +30,9 @@ class Robot:
         self._servo = Servo.from_robot(self._robot, "servo")
         await self._servo.move(self.LOWER_POSITION)
 
-        # self._wiggler will become an asyncio.Task when the hand is raised. It
-        # will wiggle the hand when it has been raised for over
-        # INACTIVITY_PERIOD_S seconds.
+        # This will become an asyncio.Task when the hand is raised. It will
+        # wiggle the hand when it has been raised for over INACTIVITY_PERIOD_S
+        # seconds.
         self._wiggler = None
 
     # TODO: remove this when we're ready

--- a/main.py
+++ b/main.py
@@ -17,17 +17,18 @@ class Robot:
     INACTIVITY_PERIOD_S = 5
 
     async def __enter__(self):
-        # This will become an asyncio.Task when the hand is raised. It will
-        # wiggle the hand when it has been raised for over INACTIVITY_PERIOD_S
-        # seconds.
-        self._wiggler = None
-
         opts = RobotClient.Options(
             refresh_interval=0,
             dial_options=DialOptions(credentials=secrets.creds)
         )
         self._robot = await RobotClient.at_address(secrets.address, opts)
         self._servo = Servo.from_robot(self._robot, "servo")
+
+        # This will become an asyncio.Task when the hand is raised. It will
+        # wiggle the hand when it has been raised for over INACTIVITY_PERIOD_S
+        # seconds.
+        self._wiggler = None
+
         await self._servo.move(self.LOWER_POSITION)
         return self
 

--- a/main.py
+++ b/main.py
@@ -33,6 +33,8 @@ class Robot:
         return self
 
     async def __aexit__(self, *exception_data):
+        if self._wiggler is not None:
+            await self.lower_hand()
         await self._robot.close()
 
     # TODO: remove this when we're ready

--- a/main.py
+++ b/main.py
@@ -115,6 +115,7 @@ class Audience:
             if self._count == 0:
                 await self._robot.lower_hand()
 
+    # TODO: either test this thoroughly or remove it. It's currently unused.
     async def set_count(self, new_value):
         """
         Call this to set the number of hands raised in the audience to a certain

--- a/main.py
+++ b/main.py
@@ -66,11 +66,6 @@ class Robot:
         await self._servo.move(self.LOWER_POSITION)
 
     async def __enter__(self):
-        """
-        This function does the initialization that would normally go in
-        __init__(), except we need asyncio functionality, so we put it here
-        instead.
-        """
         # This will become an asyncio.Task when the hand is raised. It will
         # wiggle the hand when it has been raised for over INACTIVITY_PERIOD_S
         # seconds.

--- a/main.py
+++ b/main.py
@@ -36,6 +36,10 @@ class Robot:
         # INACTIVITY_PERIOD_S seconds.
         self._wiggler = None
 
+    # TODO: remove this when we're ready
+    def get_pi(self):
+        return Board.from_robot(self.robot, "pi")
+
     async def _wiggle_on_inactivity(self):
         """
         This is a background coroutine that wiggles the hand every
@@ -128,7 +132,7 @@ async def makeRobot():
 async def main():
     async with makeRobot() as robot:
         audience = Audience(robot)
-        pi = Board.from_robot(robot.robot, "pi")
+        pi = robot.get_pi()
         button = await pi.gpio_pin_by_name("18")
         led = await pi.gpio_pin_by_name("16")
 

--- a/main.py
+++ b/main.py
@@ -26,8 +26,10 @@ class Robot:
             refresh_interval=0,
             dial_options=DialOptions(credentials=secrets.creds)
         )
+        # TODO: make this private when we're ready
         self.robot = await RobotClient.at_address(secrets.address, opts)
         self._servo = Servo.from_robot(self.robot, "servo")
+        await self._servo.move(self.LOWER_POSITION)
 
         # self._wiggler will become an asyncio.Task when the hand is raised. It
         # will wiggle the hand when it has been raised for over

--- a/main.py
+++ b/main.py
@@ -77,7 +77,6 @@ class Audience:
         self._robot = robot
         self._mutex = asyncio.Lock()
         self._count = 0  # Number of people in the audience with their hand raised
-        self._robot.lower_hand()
 
     async def increment_count(self):
         """
@@ -88,7 +87,7 @@ class Audience:
         async with self._mutex:
             self._count += 1
             if self._count == 1:
-                self._robot.raise_hand()
+                await self._robot.raise_hand()
 
     async def decrement_count(self):
         """
@@ -99,7 +98,7 @@ class Audience:
         async with self._mutex:
             self._count -= 1
             if self._count == 0:
-                self._robot.lower_hand()
+                await self._robot.lower_hand()
 
     async def set_count(self, new_value):
         """
@@ -109,9 +108,9 @@ class Audience:
         """
         async with self._mutex:
             if self._count == 0 and new_value > 0:
-                self._robot.raise_hand()
+                await self._robot.raise_hand()
             if should_lower_servo = self._count > 0 and new_value == 0:
-                self._robot.lower_hand()
+                await self._robot.lower_hand()
 
             self._count = new_value
 

--- a/main.py
+++ b/main.py
@@ -16,25 +16,6 @@ class Robot:
     WIGGLE_AMOUNT = 5
     INACTIVITY_PERIOD_S = 5
 
-    async def connect(self):
-        """
-        This function does the initialization that would normally go in
-        __init__(), except we need asyncio functionality, so we put it here
-        instead.
-        """
-        opts = RobotClient.Options(
-            refresh_interval=0,
-            dial_options=DialOptions(credentials=secrets.creds)
-        )
-        self._robot = await RobotClient.at_address(secrets.address, opts)
-        self._servo = Servo.from_robot(self._robot, "servo")
-        await self._servo.move(self.LOWER_POSITION)
-
-        # This will become an asyncio.Task when the hand is raised. It will
-        # wiggle the hand when it has been raised for over INACTIVITY_PERIOD_S
-        # seconds.
-        self._wiggler = None
-
     # TODO: remove this when we're ready
     def get_pi(self):
         return Board.from_robot(self._robot, "pi")
@@ -85,7 +66,23 @@ class Robot:
         await self._servo.move(self.LOWER_POSITION)
 
     async def __enter__(self):
-        await self.connect()
+        """
+        This function does the initialization that would normally go in
+        __init__(), except we need asyncio functionality, so we put it here
+        instead.
+        """
+        # This will become an asyncio.Task when the hand is raised. It will
+        # wiggle the hand when it has been raised for over INACTIVITY_PERIOD_S
+        # seconds.
+        self._wiggler = None
+
+        opts = RobotClient.Options(
+            refresh_interval=0,
+            dial_options=DialOptions(credentials=secrets.creds)
+        )
+        self._robot = await RobotClient.at_address(secrets.address, opts)
+        self._servo = Servo.from_robot(self._robot, "servo")
+        await self._servo.move(self.LOWER_POSITION)
         return self
 
     async def __exit__(self, *exception_data):

--- a/main.py
+++ b/main.py
@@ -29,20 +29,9 @@ class Robot:
         self.robot = await RobotClient.at_address(secrets.address, opts)
         self._servo = Servo.from_robot(self.robot, "servo")
 
-        self._mutex = asyncio.Lock()
-        self._count = 0  # Number of hands currently raised
-
         # self._wiggler will become an asyncio.Task when the hand is raised. It
         # will wiggle the hand when it has been raised for over
         # INACTIVITY_PERIOD_S seconds.
-        self._wiggler = None
-
-    def _start_wiggler(self):
-        self._wiggler = asyncio.create_task(self._wiggle_on_inactivity())
-
-    async def _stop_wiggler(self):
-        self._wiggler.cancel()
-        await self._wiggler
         self._wiggler = None
 
     async def _wiggle_on_inactivity(self):
@@ -54,11 +43,41 @@ class Robot:
         try:
             while True:
                 await asyncio.sleep(self.INACTIVITY_PERIOD_S)
-                await self._wiggle_hand()
+                for _ in range(3):
+                    await self._servo.move(self.UPPER_POSITION + self.WIGGLE_AMOUNT)
+                    await asyncio.sleep(0.3)
+                    await self._servo.move(self.UPPER_POSITION)
+                    await asyncio.sleep(0.3)
         except asyncio.CancelledError:
             return
 
     async def raise_hand(self):
+        """
+        Call this to move the servo to the raised position and start the task
+        that wiggles the hand on inactivity.
+        """
+        await self._servo.move(self.UPPER_POSITION)
+        self._wiggler = asyncio.create_task(self._wiggle_on_inactivity())
+
+    async def lower_hand(self):
+        """
+        Call this to move the servo to the lowered position and stop the
+        background task that wiggles the hand once in a while.
+        """
+        self._wiggler.cancel()
+        await self._wiggler
+        self._wiggler = None
+        await self._servo.move(self.LOWER_POSITION)
+
+
+class Audience:
+    def __init__(self, robot):
+        self._robot = robot
+        self._mutex = asyncio.Lock()
+        self._count = 0  # Number of people in the audience with their hand raised
+        self._robot.lower_hand()
+
+    async def increment_count(self):
         """
         Call this to consider 1 extra person in the audience to have raised
         their hand. If this is the first person to do so, we'll raise our
@@ -67,10 +86,9 @@ class Robot:
         async with self._mutex:
             self._count += 1
             if self._count == 1:
-                await self._servo.move(self.UPPER_POSITION)
-                self._start_wiggler()
+                self._robot.raise_hand()
 
-    async def lower_hand(self):
+    async def decrement_count(self):
         """
         Call this to consider 1 extra person in the audience to have lowered
         their hand. If this is the last person who had their hand raised, we'll
@@ -79,8 +97,7 @@ class Robot:
         async with self._mutex:
             self._count -= 1
             if self._count == 0:
-                await self._stop_wiggler()
-                await self._servo.move(self.LOWER_POSITION)
+                self._robot.lower_hand()
 
     async def set_count(self, new_value):
         """
@@ -95,22 +112,9 @@ class Robot:
             self._count = new_value
 
             if should_raise_servo:
-                await self._servo.move(self.UPPER_POSITION)
-                self._start_wiggler()
+                self._robot.raise_hand()
             if should_lower_servo:
-                await self._stop_wiggler()
-                await self._servo.move(self.LOWER_POSITION)
-
-    async def _wiggle_hand(self):
-        """
-        This moves the servo to wiggle the hand, intended to be used when we've
-        had the hand raised for a while.
-        """
-        for _ in range(3):
-            await self._servo.move(self.UPPER_POSITION + self.WIGGLE_AMOUNT)
-            await asyncio.sleep(0.3)
-            await self._servo.move(self.UPPER_POSITION)
-            await asyncio.sleep(0.3)
+                self._robot.lower_hand()
 
 
 @contextlib.asynccontextmanager
@@ -125,6 +129,7 @@ async def makeRobot():
 
 async def main():
     async with makeRobot() as robot:
+        audience = Audience(robot)
         pi = Board.from_robot(robot.robot, "pi")
         button = await pi.gpio_pin_by_name("18")
         led = await pi.gpio_pin_by_name("16")
@@ -138,9 +143,9 @@ async def main():
                 if button_state:
                     should_raise = not should_raise
                     if should_raise:
-                        await robot.raise_hand()
+                        await audience.increment_count()
                     else:
-                        await robot.lower_hand()
+                        await audience.decrement_count()
             old_state = button_state
             await led.set(button_state)
 

--- a/main.py
+++ b/main.py
@@ -124,7 +124,7 @@ class Audience:
         async with self._mutex:
             if self._count == 0 and new_value > 0:
                 await self._robot.raise_hand()
-            if should_lower_servo = self._count > 0 and new_value == 0:
+            if self._count > 0 and new_value == 0:
                 await self._robot.lower_hand()
 
             self._count = new_value

--- a/main.py
+++ b/main.py
@@ -26,9 +26,8 @@ class Robot:
             refresh_interval=0,
             dial_options=DialOptions(credentials=secrets.creds)
         )
-        # TODO: make this private when we're ready
-        self.robot = await RobotClient.at_address(secrets.address, opts)
-        self._servo = Servo.from_robot(self.robot, "servo")
+        self._robot = await RobotClient.at_address(secrets.address, opts)
+        self._servo = Servo.from_robot(self._robot, "servo")
         await self._servo.move(self.LOWER_POSITION)
 
         # self._wiggler will become an asyncio.Task when the hand is raised. It
@@ -38,7 +37,7 @@ class Robot:
 
     # TODO: remove this when we're ready
     def get_pi(self):
-        return Board.from_robot(self.robot, "pi")
+        return Board.from_robot(self._robot, "pi")
 
     async def _wiggle_on_inactivity(self):
         """
@@ -126,7 +125,7 @@ async def makeRobot():
     try:
         yield robot
     finally:
-        await robot.robot.close()
+        await robot._robot.close()
 
 
 async def main():

--- a/main.py
+++ b/main.py
@@ -106,15 +106,12 @@ class Audience:
         someone forgets to lower their hand.
         """
         async with self._mutex:
-            should_raise_servo = self._count == 0 and new_value > 0
-            should_lower_servo = self._count > 0 and new_value == 0
+            if self._count == 0 and new_value > 0:
+                self._robot.raise_hand()
+            if should_lower_servo = self._count > 0 and new_value == 0:
+                self._robot.lower_hand()
 
             self._count = new_value
-
-            if should_raise_servo:
-                self._robot.raise_hand()
-            if should_lower_servo:
-                self._robot.lower_hand()
 
 
 @contextlib.asynccontextmanager

--- a/main.py
+++ b/main.py
@@ -84,6 +84,13 @@ class Robot:
         self._wiggler = None
         await self._servo.move(self.LOWER_POSITION)
 
+    async def __enter__(self):
+        await self.connect()
+        return self
+
+    async def __exit__(self, *exception_data):
+        await self._robot.close()
+
 
 class Audience:
     def __init__(self, robot):
@@ -128,18 +135,8 @@ class Audience:
             self._count = new_value
 
 
-@contextlib.asynccontextmanager
-async def makeRobot():
-    robot = Robot()
-    await robot.connect()
-    try:
-        yield robot
-    finally:
-        await robot._robot.close()
-
-
 async def main():
-    async with makeRobot() as robot:
+    async with Robot() as robot:
         audience = Audience(robot)
         pi = robot.get_pi()
         button = await pi.gpio_pin_by_name("18")


### PR DESCRIPTION
This started out as fixing the [bug from last PR](https://github.com/viam-labs/hand_raiser/pull/5#discussion_r1207341018), and snowballed into a refactoring. Changes include:
- If the count is 0 and you explicitly set it to 0, don't crash. If the count is nonzero and you explicitly set it to a nonzero number, don't leak asyncio tasks.
- Separate the functionality into 2 distinct classes: `Robot` keeps track of the arm's position and the wiggler task, while `Audience` keeps track of how many people in the audience have their hand up (and controls the robot when this changes from "nobody" to "somebody" and back).
- Add a `Robot.get_pi` function, with a TODO to remove it again when we stop using the button in the PoC
- Move the context manager functionality into the `Robot` class itself. Not sure about this one: I'd still prefer to use something from `contextlib` instead of raw `__enter__` and `__exit__` functions, but I couldn't see the right path forward.
- With those last two changes, make all state within the robot class private, and don't use private state in a public manner.
- Inline `_wiggle_hand` to within `_wiggle_on_inactivity`. No need to have separate functions any more.
- Inline `connect` to within `__enter__`. One was just a wrapper around the other.

Not tested yet: Nicole is on vacation, and I'll do it when she returns. but I'm making this PR so I don't forget to make it later.