### PR TITLE
fix comments

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,8 +44,8 @@ class Robot:
     async def _wiggle_on_inactivity(self):
         """
         This is a background coroutine that wiggles the hand every
-        INACTIVITY_PERIOD_S seconds. It is started when the count of raised
-        hands becomes nonzero, and canceled when the count goes back to 0.
+        INACTIVITY_PERIOD_S seconds. It is started when the hand is raised,
+        and canceled when the hand is lowered.
         """
         try:
             while True:
@@ -119,8 +119,8 @@ class Audience:
     async def set_count(self, new_value):
         """
         Call this to set the number of hands raised in the audience to a certain
-        value. This is mainly used to "reset" the count of raised hands if
-        someone forgets to lower their hand.
+        value. This is mainly used to reset the count of raised hands if someone
+        forgets to lower their hand.
         """
         async with self._mutex:
             if self._count == 0 and new_value > 0:


### PR DESCRIPTION
Serves me right for not looking at the previous PR for 2 weeks, and then merging it in almost immediately afterwards! When I split the single class into one class to control the servo and a second class to count audience members, I forgot to update the docstring to match.

...and then I didn't see why I put the word "reset" in quote marks, so I changed that docstring, too. 