### PR TITLE
Tweaks from assembling the hardware

### DIFF
--- a/robot.py
+++ b/robot.py
@@ -32,6 +32,7 @@ class Robot:
     UPPER_POSITION = 30
     LOWER_POSITION = 0
     WIGGLE_AMOUNT = 5
+    WIGGLE_DELAY_S = 0.5
     INACTIVITY_PERIOD_S = 5
 
     def __init__(self, servo):
@@ -73,9 +74,9 @@ class Robot:
                 for _ in range(3):
                     await self._servo.move(self.UPPER_POSITION +
                                            self.WIGGLE_AMOUNT)
-                    await asyncio.sleep(0.3)
+                    await asyncio.sleep(self.WIGGLE_DELAY_S)
                     await self._servo.move(self.UPPER_POSITION)
-                    await asyncio.sleep(0.3)
+                    await asyncio.sleep(self.WIGGLE_DELAY_S)
         except asyncio.CancelledError:
             return
 

--- a/robot.py
+++ b/robot.py
@@ -29,9 +29,9 @@ async def create_robot(creds, address):
 
 
 class Robot:
-    UPPER_POSITION = 30
-    LOWER_POSITION = 0
-    WIGGLE_AMOUNT = 5
+    UPPER_POSITION = 93
+    LOWER_POSITION = 158
+    WIGGLE_AMOUNT = 7
     WIGGLE_DELAY_S = 0.5
     INACTIVITY_PERIOD_S = 5
 

--- a/robot.py
+++ b/robot.py
@@ -30,7 +30,7 @@ async def create_robot(creds, address):
 
 class Robot:
     UPPER_POSITION = 93
-    LOWER_POSITION = 158
+    LOWER_POSITION = 152
     WIGGLE_AMOUNT = 7  # Move this much left and right of UPPER_POSITION
     WIGGLE_DELAY_S = 0.5
     INACTIVITY_PERIOD_S = 5

--- a/robot.py
+++ b/robot.py
@@ -31,7 +31,7 @@ async def create_robot(creds, address):
 class Robot:
     UPPER_POSITION = 93
     LOWER_POSITION = 158
-    WIGGLE_AMOUNT = 7
+    WIGGLE_AMOUNT = 7  # Move this much left and right of UPPER_POSITION
     WIGGLE_DELAY_S = 0.5
     INACTIVITY_PERIOD_S = 5
 
@@ -75,8 +75,11 @@ class Robot:
                     await self._servo.move(self.UPPER_POSITION +
                                            self.WIGGLE_AMOUNT)
                     await asyncio.sleep(self.WIGGLE_DELAY_S)
-                    await self._servo.move(self.UPPER_POSITION)
+                    await self._servo.move(self.UPPER_POSITION -
+                                           self.WIGGLE_AMOUNT)
                     await asyncio.sleep(self.WIGGLE_DELAY_S)
+                # Now that we're done wiggle for now, put the arm back up.
+                await self._servo.move(self.UPPER_POSITION)
         except asyncio.CancelledError:
             return
 


### PR DESCRIPTION
This wasn't worth 3 different PRs:
- Change the upper and lower positions so the physical arm is in the right locations
- Make the delay when wiggling a parameter like the others, and slow it down
- Wiggle both left and right, not just left and straight up again.

I'll try this out more thoroughly tomorrow.