### PR TITLE
Fix bugs uncovered during demo

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,9 +8,6 @@ import secrets
 from zoom_monitor import monitor_zoom
 
 
-SERVER_PORT = 8090
-
-
 async def main():
     log_level = int(sys.argv[2]) if len(sys.argv) == 3 else 20
     with monitor_zoom(sys.argv[1], log_level) as zoom:

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -36,7 +36,6 @@ class ZoomMonitor():
         self._driver.get(raw_url)
 
         self._join_meeting()
-        self._open_participants_list()
 
     @staticmethod
     def _get_raw_url(url):
@@ -83,10 +82,19 @@ class ZoomMonitor():
         Wait until we can open the participants list, then open it, then wait
         until it's opened. This function returns nothing.
         """
+        # First, check if it's already opened, and if so return immediately.
+        try:
+            self._driver.find_element(
+                    By.CLASS_NAME, "participants-wrapper__inner")
+            return  # Already opened!
+        except NoSuchElementException:
+            pass  # We need to open it.
+
         self._wait_for_element(By.CLASS_NAME, "SvgParticipantsDefault")
-        # There's something else we're supposed to wait for, but we can't
-        # figure out what. So, instead let's just try to continue, and retry a
-        # few times if it fails.
+        # Right when we join Zoom, the participants button will exist but
+        # won't yet be clickable. There's something else we're supposed to wait
+        # for, but we can't figure out what. So, instead let's just try to
+        # continue, and retry a few times if it fails.
         for attempt in range(5):
             # We want to click on an item in the class "SvgParticipantsDefault"
             # to open the participants list. However, that element is not
@@ -154,6 +162,10 @@ class ZoomMonitor():
         """
         Return the number of people in the participants list with raised hands
         """
+        # If someone else shares their screen, it closes the participants list.
+        # So, try reopening it every time we want to count hands.
+        self._open_participants_list()
+
         # We want to find an SVG element whose class is
         # "lazy-svg-icon__icon lazy-icon-nvf/270b". However,
         # `find_elements(By.CLASS_NAME, ...)` has problems when the class name

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -192,6 +192,11 @@ class ZoomMonitor():
         # warning us about that before we can count hands again.
         self._acknowledge_recording()
 
+        # WARNING: there's a race condition right here. If someone starts recording the meeting
+        # here, after _acknowledge_recording returns and before _open_participants_list runs, we
+        # will time out opening the list and crash. It's such an unlikely event that we haven't
+        # bothered fixing it yet.
+
         # If someone else shares their screen, it closes the participants list.
         # So, try reopening it every time we want to count hands.
         self._open_participants_list()

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -141,17 +141,19 @@ class ZoomMonitor():
 
                 try:
                     outer.click()
-                    self._logger.debug("participants list found")
-                    # Now that we've clicked the participants list without
-                    # raising an exception, wait until it shows up.
-                    self._wait_for_element(
-                        By.CLASS_NAME, "participants-wrapper__inner")
-                    self._logger.info("participants list clicked!")
-                    return  # Success!
                 except ElementClickInterceptedException:
                     self._logger.debug("DOM isn't set up; wait and try again")
                     time.sleep(1)  # The DOM isn't set up; wait a little longer
                     break  # Go to the next overall attempt
+
+                self._logger.debug("participants list clicked")
+                # Now that we've clicked the participants list without raising
+                # an exception, wait until it shows up.
+                self._wait_for_element(
+                    By.CLASS_NAME, "participants-wrapper__inner")
+                self._logger.info("participants list opened")
+                return  # Success!
+
         # If we get here, none of our attempts opened the participants list.
         raise ElementClickInterceptedException(
             f"Could not open participants list after {attempt + 1} attempts")

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -33,7 +33,7 @@ class ZoomMonitor():
         chrome_options = Options()
         # Uncomment this line to keep the browser open even after this process
         # exits. It's a useful option when debugging or adding new features.
-        chrome_options.add_experimental_option("detach", True)
+        #chrome_options.add_experimental_option("detach", True)
 
         self._driver = Chrome(options=chrome_options)
 

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -77,6 +77,15 @@ class ZoomMonitor():
         self._driver.find_element(By.CSS_SELECTOR, ".zm-btn").click()
         self._logger.info("logged into Zoom successfully")
 
+    def _acknowledge_recording(self):
+        """
+        If we are notified that someone is recording this meeting, click
+        through so we can count hands some more. This notification will come
+        either at the beginning if the recording was already in progress, or
+        in the middle of the meeting if someone starts recording.
+        """
+        pass
+
     def _open_participants_list(self):
         """
         Wait until we can open the participants list, then open it, then wait
@@ -162,6 +171,10 @@ class ZoomMonitor():
         """
         Return the number of people in the participants list with raised hands
         """
+        # If someone starts recording the meeting, we'll get a pop-up modal
+        # warning us about that before we can count hands again.
+        self._acknowledge_recording()
+
         # If someone else shares their screen, it closes the participants list.
         # So, try reopening it every time we want to count hands.
         self._open_participants_list()

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -141,12 +141,12 @@ class ZoomMonitor():
 
                 try:
                     outer.click()
+                    self._logger.debug("participants list clicked")
                 except ElementClickInterceptedException:
                     self._logger.debug("DOM isn't set up; wait and try again")
                     time.sleep(1)  # The DOM isn't set up; wait a little longer
                     break  # Go to the next overall attempt
 
-                self._logger.debug("participants list clicked")
                 # Now that we've clicked the participants list without raising
                 # an exception, wait until it shows up.
                 self._wait_for_element(


### PR DESCRIPTION
1. When someone shares their screen, it closes the list of participants. So, instead of just opening it once at the beginning, try opening it every time we want to count hands.
2. When someone starts recording the screen (or when we join a new meeting with a recording already in progress), we get a warning modal we need to click through. So, look for that and click through it before trying to open the participants list.
  a. If someone records the screen, then stops recording, then starts recording again, a _different_ modal shows up. but that one doesn't obviously get in the way of opening the participants list, so I'm ignoring it. 

This has been tested in a cursory manner, but we should test it more thoroughly:
- [x] join a meeting, then have someone share their screen
- [x] join a meeting when someone is already sharing their screen
- [x] join a meeting with a recording in progress
- [x] join a meeting with a recording in progress while someone is sharing their screen
- [x] join a meeting that someone starts recording after we've joined
- [x] join a meeting, have someone share their screen, then start recording
- [x] join a meeting with a recording in progress, then stop recording and start recording again
- [x] join a meeting, then start recording, then stop recording, then start again