### PR TITLE
leave the zoom meeting cleanly

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,4 +24,4 @@ if __name__ == "__main__":
     try:
         asyncio.run(main())
     except KeyboardInterrupt:
-        pass  # Shut down smoothly when someone hits control-C.
+        pass  # Shut down cleanly when someone hits control-C.

--- a/main.py
+++ b/main.py
@@ -21,4 +21,7 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass  # Shut down smoothly when someone hits control-C.

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -40,7 +40,7 @@ class ZoomMonitor():
         # Normally, if you hit control-C, Selenium shuts down the web browser
         # immediately. However, we want to leave the meeting before
         # disconnecting. So, we need to make the subprocess running the web
-        # browser be in a separate process group than ourselves, so it doesn't
+        # browser be in a separate process group from ourselves, so it doesn't
         # receive the signal.
         # Solution taken from https://stackoverflow.com/a/62430234
         subprocess_Popen = subprocess.Popen

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -1,6 +1,5 @@
 from contextlib import contextmanager
 import functools
-import signal
 import subprocess
 import time
 import urllib.parse
@@ -43,7 +42,6 @@ class ZoomMonitor():
         # disconnecting. So, we need to make the subprocess running the web
         # browser be in a separate process group than ourselves, so it doesn't
         # receive the signal.
-
         # Solution taken from https://stackoverflow.com/a/62430234
         subprocess_Popen = subprocess.Popen
         subprocess.Popen = functools.partial(subprocess_Popen, process_group=0)

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -37,7 +37,7 @@ class ZoomMonitor():
         # exits. It's a useful option when debugging or adding new features.
         #chrome_options.add_experimental_option("detach", True)
 
-        # Normally, if you hit control-C, Selenium disconnects from the browser
+        # Normally, if you hit control-C, Selenium shuts down the web browser
         # immediately. However, we want to leave the meeting before
         # disconnecting. So, we need to make the subprocess running the web
         # browser be in a separate process group than ourselves, so it doesn't

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -1,4 +1,7 @@
 from contextlib import contextmanager
+import functools
+import signal
+import subprocess
 import time
 import urllib.parse
 
@@ -35,7 +38,17 @@ class ZoomMonitor():
         # exits. It's a useful option when debugging or adding new features.
         #chrome_options.add_experimental_option("detach", True)
 
+        # Normally, if you hit control-C, Selenium disconnects from the browser
+        # immediately. However, we want to leave the meeting before
+        # disconnecting. So, we need to make the subprocess running the web
+        # browser be in a separate process group than ourselves, so it doesn't
+        # receive the signal.
+
+        # Solution taken from https://stackoverflow.com/a/62430234
+        subprocess_Popen = subprocess.Popen
+        subprocess.Popen = functools.partial(subprocess_Popen, process_group=0)
         self._driver = Chrome(options=chrome_options)
+        subprocess.Popen = subprocess_Popen  # Undo the monkey patch
 
         raw_url = self._get_raw_url(url)
         self._logger.debug(f"parsed URL {url} to {raw_url}")
@@ -173,10 +186,6 @@ class ZoomMonitor():
         """
         try: # If anything goes wrong, close the browser anyway.
             # Find the "leave" button and click on it.
-            # TODO: this next line raises a urllib3.exceptions.MaxRetryError if
-            # called after you hit control-C to kill everything, but quits Zoom
-            # correctly if this gets called without hitting control-C. See if
-            # there's a way to get it to leave the Zoom room no matter what.
             self._driver.find_element(
                 By.CLASS_NAME, "footer__leave-btn").click()
             self._driver.find_element(

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -42,7 +42,7 @@ class ZoomMonitor():
         # disconnecting. So, we need to make the subprocess running the web
         # browser be in a separate process group from ourselves, so it doesn't
         # receive the signal.
-        # Solution taken from https://stackoverflow.com/a/62430234
+        # Solution inspired by https://stackoverflow.com/a/62430234
         subprocess_Popen = subprocess.Popen
         subprocess.Popen = functools.partial(subprocess_Popen, process_group=0)
         self._driver = Chrome(options=chrome_options)

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -41,7 +41,7 @@ class ZoomMonitor():
         # immediately. However, we want to leave the meeting before
         # disconnecting. So, we need to make the subprocess running the web
         # browser be in a separate process group from ourselves, so it doesn't
-        # receive the signal.
+        # receive the SIGINT from the control-C.
         # Solution inspired by https://stackoverflow.com/a/62430234
         subprocess_Popen = subprocess.Popen
         subprocess.Popen = functools.partial(subprocess_Popen, process_group=0)


### PR DESCRIPTION
The approach in https://stackoverflow.com/a/67755874 didn't work, but the one in https://stackoverflow.com/a/62430234 did! Now, when you hit control-C, we leave the Zoom meeting so other participants recognize that we're no longer in it, and then we don't spit out a giant stack trace at the end.