### PR TITLE
Don't crash on meeting end

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,4 +24,4 @@ if __name__ == "__main__":
     try:
         asyncio.run(main())
     except (KeyboardInterrupt, MeetingEndedException):
-        pass  # Shut down cleanly when someone hits control-C.
+        pass  # Shut down cleanly

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import sys
 from audience import Audience
 from robot import create_robot
 import secrets
-from zoom_monitor import monitor_zoom
+from zoom_monitor import monitor_zoom, MeetingEndedException
 
 
 async def main():
@@ -23,5 +23,5 @@ async def main():
 if __name__ == "__main__":
     try:
         asyncio.run(main())
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, MeetingEndedException):
         pass  # Shut down cleanly when someone hits control-C.


### PR DESCRIPTION
Tried on Ubuntu: if you have Hand Raiser Bot join a meeting and then the host of the meeting ends it for everyone, we just quit without barfing a giant stack trace. I suspect we don't need to try this out on Mac as well (I'd expect the HTML to be the same on both), but we can test it out further on Macs if anyone's worried about it.