### PR TITLE
use api key

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,14 +4,13 @@ import sys
 
 from audience import Audience
 from robot import create_robot
-import secrets
 from zoom_monitor import monitor_zoom
 
 
 async def main():
     log_level = int(sys.argv[2]) if len(sys.argv) == 3 else 20
     with monitor_zoom(sys.argv[1], log_level) as zoom:
-        async with create_robot(secrets.creds, secrets.address, log_level) as robot:
+        async with create_robot(log_level) as robot:
             audience = Audience(robot, log_level)
 
             while True:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 selenium>=4.13.0
-viam-sdk>=0.2.18
+viam-sdk>=0.9.0

--- a/robot.py
+++ b/robot.py
@@ -1,11 +1,11 @@
 import asyncio
 from contextlib import asynccontextmanager
-import secrets
 
 from viam.components.servo import Servo
 from viam.logging import getLogger, setLevel
 from viam.robot.client import RobotClient
 
+import secrets
 
 @asynccontextmanager
 async def create_robot(log_level):

--- a/robot.py
+++ b/robot.py
@@ -1,23 +1,24 @@
 import asyncio
 from contextlib import asynccontextmanager
+import secrets
 
 from viam.components.servo import Servo
 from viam.logging import getLogger, setLevel
 from viam.robot.client import RobotClient
-from viam.rpc.dial import DialOptions
 
 
 @asynccontextmanager
-async def create_robot(creds, address, log_level):
+async def create_robot(log_level):
     """
     This makes a connection to the hardware, creates a Robot object, and then
     closes the connection when the context manager exits.
     """
-    opts = RobotClient.Options(
-        refresh_interval=0,
-        dial_options=DialOptions(credentials=creds)
+    opts = RobotClient.Options.with_api_key(
+        api_key=secrets.api_key,
+        api_key_id=secrets.api_key_id
     )
-    client = await RobotClient.at_address(address, opts)
+    client = await RobotClient.at_address(secrets.address, opts)
+
     servo = Servo.from_robot(client, "servo")
 
     robot = Robot(servo, log_level)

--- a/secrets.py
+++ b/secrets.py
@@ -2,10 +2,6 @@
 # If your repo is dirty after updating this file, run:
 #     git update-index --skip-worktree secrets.py
 
-from viam.rpc.dial import Credentials
-
-creds = Credentials(
-    type="robot-location-secret",
-    payload="its-a-fake-secret")
-
 address = "not-the-real-one.viam.cloud"
+api_key = "its-a-fake-key"
+api_key_id = "its-a-fake-key-id"


### PR DESCRIPTION
Tested with Alan on Zoom.
Updated secrets to now use API keys, so got rid of credentials.

Note: `secrets.py` is now imported in `robot.py` instead of `main.py`.