### PR TITLE
Small tweaks: headless browser, update robot twice per second

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ async def main():
             while True:
                 count = zoom.count_hands()
                 await audience.set_count(count)
-                await asyncio.sleep(1)
+                await asyncio.sleep(0.5)
 
 
 if __name__ == "__main__":

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -41,6 +41,7 @@ class ZoomMonitor():
         setLevel(log_level)
 
         chrome_options = Options()
+        chrome_options.add_argument("--headless=new")
         # Uncomment this line to keep the browser open even after this process
         # exits. It's a useful option when debugging or adding new features.
         #chrome_options.add_experimental_option("detach", True)

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -42,8 +42,10 @@ class ZoomMonitor():
 
         chrome_options = Options()
         chrome_options.add_argument("--headless=new")
-        # Uncomment this line to keep the browser open even after this process
-        # exits. It's a useful option when debugging or adding new features.
+        # Uncomment this next line to keep the browser open even after this
+        # process exits. It's a useful option when debugging or adding new
+        # features, though it's most useful when you comment out the previous
+        # line so the browser is headful.
         #chrome_options.add_experimental_option("detach", True)
 
         # Normally, if you hit control-C, Selenium shuts down the web browser


### PR DESCRIPTION
The once-per-second updates felt sluggish to me.

Discussion question: having a headless browser is convenient because it doesn't get in the way, but it also removes the easiest way for you to check if things are working correctly. Should I undo that? Should I make it optional? Should I add extra logging so it's easier to check if it's working?

This PR was trivial to make; I'm perfectly happy to throw it out, or rework it entirely, or anything else.