### PR TITLE
Better logging, add argparse

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
+import argparse
 import asyncio
+import logging
 import sys
 
 from audience import Audience
@@ -7,9 +9,17 @@ from robot import create_robot
 from zoom_monitor import monitor_zoom, MeetingEndedException
 
 
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("url", help="URL of Zoom meeting. Can be a Google redirect.")
+    parser.add_argument("--debug", help="Turn on debugging logs", action="store_true")
+    return parser.parse_args()
+
+
 async def main():
-    log_level = int(sys.argv[2]) if len(sys.argv) == 3 else 20
-    with monitor_zoom(sys.argv[1], log_level) as zoom:
+    args = parse_args()
+    log_level = logging.DEBUG if args.debug else logging.INFO
+    with monitor_zoom(args.url, log_level) as zoom:
         async with create_robot(log_level) as robot:
             audience = Audience(robot, log_level)
 

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -146,7 +146,7 @@ class ZoomMonitor():
             try:
                 button = self._find_participants_button()
             except NoSuchElementException:
-                self._logger.debug("Could not find participants button.")
+                self._logger.info("Could not find participants button.")
                 time.sleep(1)
                 continue  # Go to the next attempt
 
@@ -158,7 +158,7 @@ class ZoomMonitor():
                 button.click()
             except (ElementClickInterceptedException,
                     ElementNotInteractableException) as e:
-                self._logger.debug(f"DOM isn't set up ({e}); try again soon.")
+                self._logger.info(f"DOM isn't set up ({e}); try again soon.")
                 time.sleep(1)
                 continue  # Go to the next attempt
             self._logger.debug("participants list clicked")
@@ -172,8 +172,8 @@ class ZoomMonitor():
                 self._wait_for_element(
                     By.CLASS_NAME, "participants-wrapper__inner", timeout_s=1)
             except TimeoutException:
-                self._logger.debug("timed out waiting for participants list,"
-                                   "will try clicking again soon.")
+                self._logger.info("timed out waiting for participants list,"
+                                  "will try clicking again soon.")
                 continue  # Go to the next attempt
             self._logger.info("participants list opened")
             return  # Success!


### PR DESCRIPTION
1. If you're unable to find or open the participants list, log that even if you don't have debug logging turned on.
2. Make it way easier to turn on debug logging
3. Use `argparse` to make it more obvious what the arguments to the command are.

Tried locally: `--help`, `--debug`, and `<no-flags>` all work as intended, and not providing any arguments (not providing a URL to Zoom) gives a slightly more obvious error message.