### PR TITLE
First attempt at migrating to Playwright

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ When we have large meetings, sometimes the remote employees are unable to partic
 6. Step 3 probably made the repo dirty. Run `git update-index --skip-worktree secrets.py` to make the repo clean again.
 
 ## Running
+
 1. When you want Hand Raiser Bot to join a meeting, run `./main.py '<url-of-zoom-meeting>'` to start it. The URL likely contains a question mark, so we recommend enclosing the entire URL in single quotes so your terminal doesn't try pattern-matching on it.
    - Note that if you copy a Slack-generated Zoom link, the robot will end up opening Slack and not a Zoom window. To work around this, get in the Zoom yourself, click the up arrow on the Participants list button, and click "Copy invite link." That URL will work with the hand raiser.
 2. This will open a Chrome window and join the Zoom meeting as the user "Hand Raiser Bot."
@@ -21,9 +22,10 @@ When we have large meetings, sometimes the remote employees are unable to partic
 6. When the meeting is over (or when you want Hand Raiser Bot to leave), hit control-C in the terminal to shut everything down. This will also lower the servo even if someone in the Zoom meeting still has their hand raised.
 
 ## Code Layout
+
 - `robot.py` talks to `viam-server` to move the hardware itself. The code in this file raises and lowers the servo, and wiggles it if it has been raised for a while.
 - `audience.py` keeps track of how many hands are raised. This tells the robot when it's time to raise and lower the hand.
-- `zoom_monitor.py` uses Selenium to open a web browser and join the Zoom meeting. It counts how many participants in the meeting have their hands raised.
-  - As of summer 2023, Zoom did not have an official API for participant reactions like whether someone has raised their hand. Consequently, we're getting this data by webscraping with Selenium.
+- `zoom_monitor.py` uses Playwright to open a web browser and join the Zoom meeting. It counts how many participants in the meeting have their hands raised.
+  - As of summer 2023, Zoom did not have an official API for participant reactions like whether someone has raised their hand. Consequently, we're getting this data by webscraping with Playwright.
 - `secrets.py` contains the way to connect to the robot itself. This repo does not contain production data: this file must be edited before things will work.
 - `main.py` ties everything together: it sets up a ZoomMonitor, connects to a robot, wraps the robot in an Audience object, and then sets the hand count in the Audience based on what is reported from the ZoomMonitor.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ When we have large meetings, sometimes the remote employees are unable to partic
 
 1. Clone this repo locally.
 2. Run `pip install -r requirements.txt` to install the dependencies.
-3. Edit `secrets.py` so it contains the robot's secret and URL. You can get these from anyone who worked on this project.
-4. Step 3 probably made the repo dirty. Run `git update-index --skip-worktree secrets.py` to make the repo clean again.
+3. Run `playwright install`.
+4. On Ubuntu, run `sudo apt-get install libavif16`. Figure out how to do this on Mac.
+5. Edit `secrets.py` so it contains the robot's secret and URL. You can get these from anyone who worked on this project.
+6. Step 3 probably made the repo dirty. Run `git update-index --skip-worktree secrets.py` to make the repo clean again.
 
 ## Running
 1. When you want Hand Raiser Bot to join a meeting, run `./main.py '<url-of-zoom-meeting>'` to start it. The URL likely contains a question mark, so we recommend enclosing the entire URL in single quotes so your terminal doesn't try pattern-matching on it.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ When we have large meetings, sometimes the remote employees are unable to partic
 1. Clone this repo locally.
 2. Run `pip install -r requirements.txt` to install the dependencies.
 3. Run `playwright install`.
-4. On Ubuntu, run `sudo apt-get install libavif16`. Figure out how to do this on Mac.
+4. On Ubuntu, run `sudo apt-get install libavif16`. On Mac, run `brew install libavif`.
 5. Edit `secrets.py` so it contains the robot's secret and URL. You can get these from anyone who worked on this project.
 6. Step 3 probably made the repo dirty. Run `git update-index --skip-worktree secrets.py` to make the repo clean again.
 

--- a/browser.py
+++ b/browser.py
@@ -16,28 +16,7 @@ async def spawn_driver(playwright):
 
     Return the created driver.
     """
-    print("monkey patching...")
-    asyncio_create_subprocess_exec = asyncio.create_subprocess_exec
-    asyncio_create_subprocess_shell = asyncio.create_subprocess_shell
-    if sys.version_info.major == 3 and sys.version_info.minor >= 11:
-        # In recent versions of Python, Popen has a process_group argument
-        # to put the new process in its own group.
-        asyncio.create_subprocess_exec = functools.partial(
-            asyncio_create_subprocess_exec, process_group=0)
-        asyncio.create_subprocess_shell = functools.partial(
-            asyncio_create_subprocess_shell, process_group=0)
-    else:
-        # In older versions, set a pre-execution function to create its own
-        # process group instead.
-        asyncio.create_subprocess_exec = functools.partial(
-            asyncio_create_subprocess_exec, preexec_fn=lambda: os.setpgid(0, 0))
-        asyncio.create_subprocess_shell = functools.partial(
-            asyncio_create_subprocess_shell, preexec_fn=lambda: os.setpgid(0, 0))
-    driver = await playwright.webkit.launch(headless=False)
-    # Undo the monkey patch
-    asyncio.create_subprocess_exec = asyncio_create_subprocess_exec
-    asyncio.create_subprocess_shell = asyncio_create_subprocess_shell
-    print("done monkey patching!")
+    driver = await playwright.webkit.launch(headless=False, handle_sigint=False)
     return driver
 
 

--- a/browser.py
+++ b/browser.py
@@ -1,16 +1,14 @@
+import asyncio
 import functools
 import os
 import socket
 import subprocess
 import sys
 
-from selenium.webdriver import Chrome
-from selenium.webdriver.chrome.options import Options
 
-
-def spawn_driver():
+async def spawn_driver(playwright):
     """
-    Normally, if you hit control-C, Selenium shuts down the web browser
+    Normally, if you hit control-C, Playwright shuts down the web browser
     immediately, but we want to leave the meeting before disconnecting.
     Put the subprocess running the web browser in a separate process group
     from ourselves, so it doesn't receive the SIGINT from the control-C.
@@ -18,20 +16,30 @@ def spawn_driver():
 
     Return the created driver.
     """
-    subprocess_Popen = subprocess.Popen
+    print("monkey patching...")
+    asyncio_create_subprocess_exec = asyncio.create_subprocess_exec
+    asyncio_create_subprocess_shell = asyncio.create_subprocess_shell
     if sys.version_info.major == 3 and sys.version_info.minor >= 11:
         # In recent versions of Python, Popen has a process_group argument
         # to put the new process in its own group.
-        subprocess.Popen = functools.partial(
-            subprocess_Popen, process_group=0)
+        asyncio.create_subprocess_exec = functools.partial(
+            asyncio_create_subprocess_exec, process_group=0)
+        asyncio.create_subprocess_shell = functools.partial(
+            asyncio_create_subprocess_shell, process_group=0)
     else:
         # In older versions, set a pre-execution function to create its own
         # process group instead.
-        subprocess.Popen = functools.partial(
-            subprocess_Popen, preexec_fn=lambda: os.setpgid(0, 0))
-    driver = Chrome(options=get_chrome_options())
-    subprocess.Popen = subprocess_Popen  # Undo the monkey patch
+        asyncio.create_subprocess_exec = functools.partial(
+            asyncio_create_subprocess_exec, preexec_fn=lambda: os.setpgid(0, 0))
+        asyncio.create_subprocess_shell = functools.partial(
+            asyncio_create_subprocess_shell, preexec_fn=lambda: os.setpgid(0, 0))
+    driver = await playwright.webkit.launch(headless=False)
+    # Undo the monkey patch
+    asyncio.create_subprocess_exec = asyncio_create_subprocess_exec
+    asyncio.create_subprocess_shell = asyncio_create_subprocess_shell
+    print("done monkey patching!")
     return driver
+
 
 def get_chrome_options():
     chrome_options = Options()

--- a/main.py
+++ b/main.py
@@ -23,9 +23,6 @@ async def main():
         async with create_robot(log_level) as robot:
             audience = Audience(robot, log_level)
 
-            #print("sleeping...")
-            #await asyncio.sleep(600)
-
             while True:
                 count = await zoom.count_hands()
                 await audience.set_count(count)

--- a/main.py
+++ b/main.py
@@ -23,6 +23,9 @@ async def main():
         async with create_robot(log_level) as robot:
             audience = Audience(robot, log_level)
 
+            #print("sleeping...")
+            #await asyncio.sleep(600)
+
             while True:
                 count = await zoom.count_hands()
                 await audience.set_count(count)

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ def parse_args():
 async def main():
     args = parse_args()
     log_level = logging.DEBUG if args.debug else logging.INFO
-    with monitor_zoom(args.url, log_level) as zoom:
+    async with monitor_zoom(args.url, log_level) as zoom:
         async with create_robot(log_level) as robot:
             audience = Audience(robot, log_level)
 

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ async def main():
             audience = Audience(robot, log_level)
 
             while True:
-                count = zoom.count_hands()
+                count = await zoom.count_hands()
                 await audience.set_count(count)
                 await asyncio.sleep(0.5)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 playwright==1.50.0
-selenium>=4.13.0
 viam-sdk>=0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+playwright==1.50.0
 selenium>=4.13.0
 viam-sdk>=0.9.0

--- a/robot.py
+++ b/robot.py
@@ -77,7 +77,7 @@ class Robot:
             self._logger.warning(
                 "LOGIC BUG: trying to raise already-raised hand")
             return
-        self._logger.debug("raise hand")
+        self._logger.info("raise hand")
         await self._servo.move(self.UPPER_POSITION)
         self._wiggler = asyncio.create_task(self._wiggle_on_inactivity())
 
@@ -93,7 +93,7 @@ class Robot:
         self._wiggler.cancel()
         await self._wiggler
         self._wiggler = None
-        self._logger.debug("lower hand")
+        self._logger.info("lower hand")
         await self._servo.move(self.LOWER_POSITION)
 
     async def _wiggle_on_inactivity(self):
@@ -106,7 +106,7 @@ class Robot:
             while True:
                 await asyncio.sleep(self.INACTIVITY_PERIOD_S)
 
-                self._logger.debug("wiggle wiggle wiggle")
+                self._logger.info("wiggle wiggle wiggle")
                 await self._servo.move(self.UPPER_POSITION + self.WIGGLE_AMOUNT)
                 await asyncio.sleep(self.WIGGLE_DELAY_S)
                 await self._servo.move(self.UPPER_POSITION - self.WIGGLE_AMOUNT)

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -181,6 +181,7 @@ class ZoomMonitor():
             await self._driver.get_by_role("menuitem", name="Leave Meeting").click()
         except Exception as e:
             print(f"encountered exception: {type(e)} {e}")
+            raise
         finally:
             await self._browser.close()
 

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -1,6 +1,5 @@
 import asyncio
 from contextlib import asynccontextmanager
-import time
 import urllib.parse
 
 from playwright.async_api import async_playwright, TimeoutError

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -44,6 +44,7 @@ class ZoomMonitor():
         setLevel(log_level)
 
         # TODO: move this into browser.py
+        #self._browser = await browser.spawn_driver(p)
         self._browser = await p.webkit.launch(headless=False)
         self._driver = await self._browser.new_page()
 
@@ -195,6 +196,8 @@ class ZoomMonitor():
                 return  # Just abandon the meeting without trying to leave it.
 
             # Find the "leave" button and click on it.
+            #print("sleeping for 10 minutes...")
+            #time.sleep(600)
             leave_button = await self._driver.query_selector(
                     ".footer__leave-btn")
             await leave_button.click()

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -84,7 +84,6 @@ class ZoomMonitor():
         button = await self._driver.query_selector(".zm-btn")
         await button.click()
         await self._driver.wait_for_selector(PARTICIPANTS_BTN, state="attached")
-        await self._wait_for_element(PARTICIPANTS_BTN, timeout_s=30)
         self._logger.info("logged into Zoom successfully")
 
     async def _wait_for_element(self, value, *, timeout_s=5):

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -44,8 +44,7 @@ class ZoomMonitor():
         setLevel(log_level)
 
         # TODO: move this into browser.py
-        #self._browser = await browser.spawn_driver(p)
-        self._browser = await p.webkit.launch(headless=False)
+        self._browser = await browser.spawn_driver(p)
         self._driver = await self._browser.new_page()
 
         raw_url = self._get_raw_url(url)
@@ -191,6 +190,8 @@ class ZoomMonitor():
         """
         Leave the meeting and shut down the web server.
         """
+        print("about to clean up! sleeping for 10 minutes...")
+        time.sleep(600)
         try:  # If anything goes wrong, close the browser anyway.
             if self._meeting_ended:
                 return  # Just abandon the meeting without trying to leave it.

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -190,21 +190,17 @@ class ZoomMonitor():
         """
         Leave the meeting and shut down the web server.
         """
-        print("about to clean up! sleeping for 10 minutes...")
-        time.sleep(600)
         try:  # If anything goes wrong, close the browser anyway.
             if self._meeting_ended:
                 return  # Just abandon the meeting without trying to leave it.
 
             # Find the "leave" button and click on it.
-            #print("sleeping for 10 minutes...")
-            #time.sleep(600)
-            leave_button = await self._driver.query_selector(
-                    ".footer__leave-btn")
-            await leave_button.click()
-            confirm_button = await self._driver.query_selector(
-                    ".leave-meeting-options__btn")
-            await confirm_button.click()
+            leave_button = self._driver.get_by_role("button", name="Leave")
+            # Double-clicking here is super weird, but single-clicking doesn't seem to work!?
+            await leave_button.dblclick()
+            await self._driver.get_by_role("menuitem", name="Leave Meeting").click()
+        except Exception as e:
+            print(f"encountered exception: {type(e)} {e}")
         finally:
             await self._browser.close()
 

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -156,7 +156,7 @@ class ZoomMonitor():
                     ".participants-wrapper__inner", timeout_s=1)
             except TimeoutError:
                 self._logger.info("timed out waiting for participants list,"
-                                  "will try clicking again soon.")
+                                  " will try clicking again soon.")
                 continue  # Go to the next attempt
             self._logger.info("participants list opened")
             return  # Success!

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -122,7 +122,8 @@ class ZoomMonitor():
             return  # No one has started recording a video recently!
 
         # Click "Got it" to acknowledge that the meeting is being recorded.
-        await outer.query_selector(".zm-btn--primary").click()
+        got_it_button = await outer.query_selector(".zm-btn--primary")
+        await got_it_button.click()
 
     async def _open_participants_list(self):
         """
@@ -194,8 +195,12 @@ class ZoomMonitor():
                 return  # Just abandon the meeting without trying to leave it.
 
             # Find the "leave" button and click on it.
-            await self._driver.query_selector(".footer__leave-btn").click()
-            await self._driver.query_selector(".leave-meeting-options__btn").click()
+            leave_button = await self._driver.query_selector(
+                    ".footer__leave-btn")
+            await leave_button.click()
+            confirm_button = await self._driver.query_selector(
+                    ".leave-meeting-options__btn")
+            await confirm_button.click()
         finally:
             await self._browser.close()
 

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -108,22 +108,6 @@ class ZoomMonitor():
             self._meeting_ended = True  # Don't try logging out later
             raise MeetingEndedException()
 
-    async def _ignore_recording(self):
-        """
-        If we are notified that someone is recording this meeting, click past
-        so we can count hands some more. This notification can come either at
-        the beginning if we joined when the recording was already in progress,
-        or in the middle of the meeting if someone starts recording.
-        """
-        outer = await self._driver.query_selector(
-                ".recording-disclaimer-dialog")
-        if not outer:
-            return  # No one has started recording a video recently!
-
-        # Click "Got it" to acknowledge that the meeting is being recorded.
-        got_it_button = await outer.query_selector(".zm-btn--primary")
-        await got_it_button.click()
-
     async def _open_participants_list(self):
         """
         Wait until we can open the participants list, then open it, then wait
@@ -188,13 +172,6 @@ class ZoomMonitor():
         Return the number of people in the participants list with raised hands
         """
         await self._check_if_meeting_ended()
-        await self._ignore_recording()
-
-        # WARNING: there's a race condition right here. If someone starts
-        # recording the meeting here, after _ignore_recording returns and
-        # before _open_participants_list runs, we will time out opening the
-        # list and crash. It's such an unlikely event that we haven't bothered
-        # fixing it yet.
 
         # If someone else shares their screen, it closes the participants list.
         # So, try reopening it every time we want to count hands.

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -137,7 +137,7 @@ class ZoomMonitor():
         # Right when we join Zoom, the participants button is not clickable so
         # we have to wait. Attempt to click the button a few times.
         for attempt in range(5):
-            button = await self._find_participants_button()
+            button = self._driver.get_by_role("button", name="open the participants list")
             if not button:
                 self._logger.info("Could not find participants button.")
                 # TODO: move to asyncio.sleep()
@@ -165,26 +165,6 @@ class ZoomMonitor():
         # If we get here, none of our attempts opened the participants list.
         raise ValueError(
             f"Could not open participants list after {attempt + 1} attempts")
-
-    async def _find_participants_button(self):
-        """
-        We want to click on an item with the participants icon. However, the
-        icon itself is not clickable. A click would be intercepted by its
-        grandparent element, a button with the class
-        "footer-button-base__button". Since it's not obvious how to click an
-        SVG element's grandparent, look through all footer buttons.
-
-        Return the button that contains the participants icon.
-        """
-        for outer in await self._driver.query_selector_all(
-                ".footer-button-base__button"):
-            self._logger.debug(f"trying to find participants button in {outer}")
-            # Check if this footer button contains the participants
-            if await outer.query_selector(PARTICIPANTS_BTN):
-                return outer
-            self._logger.debug("participants not present, next...")
-            continue  # wrong footer element, try the next one
-        raise ValueError("could not find participants button")
 
     async def clean_up(self):
         """

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -19,7 +19,7 @@ import browser
 
 
 # XPath path expression to find participants button node
-PARTICIPANTS_BTN = ".//*[contains(@class, 'SvgParticipants')]"
+PARTICIPANTS_BTN = "//*[contains(@class, 'SvgParticipants')]"
 
 
 @asynccontextmanager
@@ -102,8 +102,9 @@ class ZoomMonitor():
         and value. If `timeout_s` seconds elapse without such an element
         appearing, we raise a TimeoutError.
         """
+        # Playwright's timeouts are all in milliseconds
         await self._driver.wait_for_selector(
-            value, state="attached", timeout=timeout_s)
+            value, state="attached", timeout=timeout_s * 1000)
 
     async def _check_if_meeting_ended(self):
         """
@@ -245,6 +246,7 @@ class ZoomMonitor():
         # raised" emoji). Elements whose class contains "270b" show up in
         # several places, however, so we restrict it to only the ones that are
         # within the participants list.
-        return await len(self._driver.query_selector_all(
+        hands = await self._driver.query_selector_all(
             "//*[@class='participants-wrapper__inner']"
-            "//*[contains(@class, '270b')]"))
+            "//*[contains(@class, '270b')]")
+        return len(hands)

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -2,16 +2,6 @@ from contextlib import asynccontextmanager
 import time
 import urllib.parse
 
-"""
-from selenium.common.exceptions import (ElementClickInterceptedException,
-                                        ElementNotInteractableException,
-                                        NoSuchElementException,
-                                        TimeoutException
-                                        )
-from selenium.webdriver.common.action_chains import ActionChains
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.wait import WebDriverWait
-"""
 from playwright.async_api import async_playwright, TimeoutError
 from viam.logging import getLogger, setLevel
 
@@ -44,7 +34,7 @@ class MeetingEndedException(Exception):
 
 class ZoomMonitor():
     """
-    Given a URL to a Zoom meeting, join the meeting using Selenium controlling
+    Given a URL to a Zoom meeting, join the meeting using Playwright controlling
     a Chrome browser. We provide a way to count how many meeting participants
     currently have their hands raised.
     """
@@ -154,18 +144,6 @@ class ZoomMonitor():
                 continue  # Go to the next attempt
 
             await button.click()
-
-            ## Sometimes, the button is hidden off the bottom of the window,
-            ## but moving the mouse to it will make it visible again. This
-            ## tends to happen after someone stops sharing their screen.
-            #ActionChains(self._driver).move_to_element(button).perform()
-            #try:
-            #    button.click()
-            #except (ElementClickInterceptedException,
-            #        ElementNotInteractableException) as e:
-            #    self._logger.info(f"DOM isn't set up ({e}); try again soon.")
-            #    time.sleep(1)
-            #    continue  # Go to the next attempt
             self._logger.debug("participants list clicked")
 
             try:

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -22,7 +22,7 @@ async def monitor_zoom(url, log_level):
         try:
             yield zoom
         finally:
-            zoom.clean_up()
+            await zoom.clean_up()
 
 
 class MeetingEndedException(Exception):
@@ -57,7 +57,7 @@ class ZoomMonitor():
     def _get_raw_url(url):
         """
         Remove any Google redirection or Zoom prompts to the Zoom meeting.
-        Returns the URL needed to connect inside the Selenium browser.
+        Returns the URL needed to connect inside the Playwright browser.
         """
         # Remove all blackslashes since shells may automatically add them.
         url = url.replace("\\", "")

--- a/zoom_monitor.py
+++ b/zoom_monitor.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import asynccontextmanager
 import time
 import urllib.parse
@@ -140,8 +141,7 @@ class ZoomMonitor():
             button = self._driver.get_by_role("button", name="open the participants list")
             if not button:
                 self._logger.info("Could not find participants button.")
-                # TODO: move to asyncio.sleep()
-                time.sleep(1)
+                await asyncio.sleep(1)
                 continue  # Go to the next attempt
 
             await button.click()


### PR DESCRIPTION
It's not quite right: when you hit control-C, it craps the bed because you can't call `self._browser.close()` while you're in the middle of reading from the driver, and you're in the middle of reading from the driver because there is some `coroutine 'Page.query_selector' was never awaited`, but I don't see where that is yet.

but it's pretty close! Close enough that I want more eyes on this. With more eyes, perhaps we can find the coroutine that needs awaiting, and then clean up the rest before merging...